### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microfluidica/normaldistrib/security/code-scanning/1](https://github.com/microfluidica/normaldistrib/security/code-scanning/1)

To fix the problem, we should set the `permissions` key at the root of the workflow. The safest practice is to assign the minimum privileges required for the workflow to function.  
For most CI workflows (e.g., running lint, build, format checks), only read access to the repository contents (`contents: read`) is required, as these jobs do not generally create or modify anything in the repository or open issues/PRs.  
Therefore, we should add, at the top level (e.g., after the `name:` declaration and before `on:`), the following:

```yaml
permissions:
  contents: read
```

This ensures that **all jobs** in the workflow will default to this minimum permission unless overridden on a per-job basis. No further permissions are needed for the jobs shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
